### PR TITLE
Add printLog flag to disable logging

### DIFF
--- a/src/main/java/org/tussleframework/ProcBenchmark.java
+++ b/src/main/java/org/tussleframework/ProcBenchmark.java
@@ -90,7 +90,10 @@ public class ProcBenchmark implements Benchmark {
     }
 
     protected void initCmd() throws TussleException {
-        procLog = new LoggerTool.LogOutputStream(config.logPrefix != null ? config.logPrefix : String.format("[%s] ", config.name), config.logSuffix != null ? config.logSuffix : "");
+        if (config.printLog)
+            procLog = new LoggerTool.LogOutputStream(config.logPrefix != null ? config.logPrefix : String.format("[%s] ", config.name), config.logSuffix != null ? config.logSuffix : "");
+        else
+            procLog = LoggerTool.nullOutputStream();
         if (config.init != null && !config.init.isEmpty()) {
             log(" --- BENCHMARK PROCESS INIT --- ");
             ProcTool.runProcess("init", config.makeCmd(config.init, config.getArgs(new RunArgs())), procLog);

--- a/src/main/java/org/tussleframework/ProcConfig.java
+++ b/src/main/java/org/tussleframework/ProcConfig.java
@@ -47,6 +47,7 @@ import org.tussleframework.tools.ProcTool.CmdVars;
  * Basic benchmark configuration
  */
 public class ProcConfig extends BenchmarkConfig {
+    public boolean printLog;
     public String logPrefix;
     public String logSuffix;
     public String runResult;

--- a/src/main/java/org/tussleframework/tools/LoggerTool.java
+++ b/src/main/java/org/tussleframework/tools/LoggerTool.java
@@ -49,6 +49,33 @@ public class LoggerTool {
     private LoggerTool() {
     }
 
+    public static OutputStream nullOutputStream() {
+        return new OutputStream() {
+            private volatile boolean closed;
+
+            private void ensureOpen() throws IOException {
+                if (closed) {
+                    throw new IOException("Stream closed");
+                }
+            }
+
+            @Override
+            public void write(int b) throws IOException {
+                ensureOpen();
+            }
+
+            @Override
+            public void write(byte b[], int off, int len) throws IOException {
+                ensureOpen();
+            }
+
+            @Override
+            public void close() {
+                closed = true;
+            }
+        };
+    }
+
     public static void init(String name, String handlers) {
         try {
             if (handlers != null) {


### PR DESCRIPTION
Added new flag "printLog" in ProcConfig. Now it is possible to turn off external process output logging.
It will be useful for disabling log duplication if external process is logging own actions itself.